### PR TITLE
Fix the dependency to the version based

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,36 +13,36 @@ branches:
 
 matrix:
   include:
+    # - os: linux
+    #   dist: xenial
+    #   sudo: required
+    #   services: docker
+    #   env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.0.3 SWIFT_SNAPSHOT=4.0.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+    # - os: linux
+    #   dist: xenial
+    #   sudo: required
+    #   services: docker
+    #   env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.1.3 SWIFT_SNAPSHOT=4.1.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+    # - os: linux
+    #   dist: xenial
+    #   sudo: required
+    #   services: docker
+    #   env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.2.4 SWIFT_SNAPSHOT=4.2.4 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.0.3 SWIFT_SNAPSHOT=4.0.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.0.3 SWIFT_SNAPSHOT=5.0.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.1.3 SWIFT_SNAPSHOT=4.1.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.2.4 SWIFT_SNAPSHOT=4.2.4 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.0.3 SWIFT_SNAPSHOT=5.0.3 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.3.3 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.3.3 DOCKER_PRIVILEGED=true DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,27 +17,32 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:4.0.3 SWIFT_SNAPSHOT=4.0.3 DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.0.3 SWIFT_SNAPSHOT=4.0.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:4.1.3 SWIFT_SNAPSHOT=4.1.3 DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.1.3 SWIFT_SNAPSHOT=4.1.3 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:4.2.4 SWIFT_SNAPSHOT=4.2.4 DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:4.2.4 SWIFT_SNAPSHOT=4.2.4 DOCKER_PRIVILEGED=true DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.3-xenial SWIFT_SNAPSHOT=5.0.3 DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.0.3 SWIFT_SNAPSHOT=5.0.3 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.1 DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.3.3 DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PRIVILEGED=true SWIFT_TEST_ARGS="--parallel --sanitize=thread" DOCKER_PACKAGES="libpq-dev postgresql postgresql-contrib locales locales-all" CUSTOM_BUILD_SCRIPT=.build-docker
     - os: linux
       dist: xenial
       sudo: required

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        //.package(url: "https://github.com/Kitura/Swift-Kuery.git", from: "3.1.0"),
-        .package(url: "https://github.com/Kitura/Swift-Kuery.git", .branch("master")),
+        .package(url: "https://github.com/Kitura/Swift-Kuery.git", from: "3.0.200"),
         ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Change the dependency of Swift-Kuery to the version based dependency.
This will make the integration of Swifty-Kuery-PostgreSQL from multiple packages easier and avoid the error message type like this one:
`error: because package swift-kuery-postgresql is required using a version-based requirement and it depends on unversion package swift-kuery and no versions of Swift-Kuery-PostgreSQL match the requirement 2.1.201..<3.0.0, Swift-Kuery-PostgreSQL >=2.1.200 is forbidden.`